### PR TITLE
Setting type attribute on button element prevents submission

### DIFF
--- a/comboTreePlugin.js
+++ b/comboTreePlugin.js
@@ -46,7 +46,7 @@
         this._elemInput.wrap('<div id="'+ this.comboTreeId + 'InputWrapper" class="comboTreeInputWrapper"></div>');
         this._elemWrapper = $('#' + this.comboTreeId + 'Wrapper');
 
-        this._elemArrowBtn = $('<button id="' + this.comboTreeId + 'ArrowBtn" class="comboTreeArrowBtn"><span class="comboTreeArrowBtnImg">▼</span></button>');
+        this._elemArrowBtn = $('<button id="' + this.comboTreeId + 'ArrowBtn" class="comboTreeArrowBtn" type="button"><span class="comboTreeArrowBtnImg">▼</span></button>');
         this._elemInput.after(this._elemArrowBtn);
         this._elemWrapper.append('<div id="' + this.comboTreeId + 'DropDownContainer" class="comboTreeDropDownContainer"><div class="comboTreeDropDownContent"></div>');
         


### PR DESCRIPTION
When combo-tree is used within a form, setting the type attribute on the button element to "button" will prevent form submission.